### PR TITLE
[chore] Improve iOS build setup and add codegen lane

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -54,6 +54,21 @@ lane :setup_env do
   UI.success("Ready to build with: bundle exec fastlane ios build flavor:dev")
 end
 
+desc "Run code generation (build_runner) for all packages"
+lane :codegen do
+  root = File.expand_path("..", Dir.pwd)
+  packages = Dir.glob("#{root}/**/pubspec.yaml")
+    .select { |f| File.read(f).include?("build_runner") }
+    .map { |f| File.dirname(f) }
+
+  packages.each do |pkg|
+    UI.message("Running build_runner in #{pkg}...")
+    sh("cd #{pkg} && dart run build_runner build --delete-conflicting-outputs")
+  end
+
+  UI.success("Code generation complete for #{packages.size} packages")
+end
+
 desc "Run tests"
 lane :test do
   sh("cd #{Dir.pwd} && flutter test")
@@ -92,8 +107,11 @@ platform :ios do
   desc "Build iOS app for a given flavor"
   lane :build do |options|
     flavor = options[:flavor] || "dev"
-    UI.message("Building iOS with flavor: #{flavor}")
-    sh("cd #{Dir.pwd} && flutter build ios --flavor=#{flavor} --dart-define-from-file=secrets/.env")
+    simulator = options[:simulator] == true || options[:simulator] == "true"
+    UI.message("Building iOS with flavor: #{flavor}#{simulator ? ' (simulator)' : ''}")
+    cmd = "cd #{Dir.pwd} && flutter build ios --flavor=#{flavor} --dart-define-from-file=secrets/.env"
+    cmd += " --simulator" if simulator
+    sh(cmd)
   end
 
   desc "Release iOS (build + prepare for upload)"

--- a/fastlane/README.md
+++ b/fastlane/README.md
@@ -29,6 +29,14 @@ Setup IDE run configurations
 
 Configure environment variables (secrets/.env)
 
+### codegen
+
+```sh
+[bundle exec] fastlane codegen
+```
+
+Run code generation (build_runner) for all packages
+
 ### test
 
 ```sh

--- a/ios/Flutter/Debug-dev.xcconfig
+++ b/ios/Flutter/Debug-dev.xcconfig
@@ -1,2 +1,5 @@
 #include? "../Pods/Target Support Files/Pods-Runner/Pods-Runner.debug-dev.xcconfig"
 #include "Generated.xcconfig"
+CODE_SIGN_STYLE=Manual
+PROVISIONING_PROFILE_SPECIFIER=
+DEVELOPMENT_TEAM=

--- a/ios/Flutter/Debug-prod.xcconfig
+++ b/ios/Flutter/Debug-prod.xcconfig
@@ -1,2 +1,5 @@
 #include? "../Pods/Target Support Files/Pods-Runner/Pods-Runner.debug-prod.xcconfig"
 #include "Generated.xcconfig"
+CODE_SIGN_STYLE=Manual
+PROVISIONING_PROFILE_SPECIFIER=
+DEVELOPMENT_TEAM=

--- a/ios/Flutter/Debug-staging.xcconfig
+++ b/ios/Flutter/Debug-staging.xcconfig
@@ -1,2 +1,5 @@
 #include? "../Pods/Target Support Files/Pods-Runner/Pods-Runner.debug-staging.xcconfig"
 #include "Generated.xcconfig"
+CODE_SIGN_STYLE=Manual
+PROVISIONING_PROFILE_SPECIFIER=
+DEVELOPMENT_TEAM=

--- a/ios/Flutter/Profile-dev.xcconfig
+++ b/ios/Flutter/Profile-dev.xcconfig
@@ -1,2 +1,5 @@
 #include? "../Pods/Target Support Files/Pods-Runner/Pods-Runner.profile-dev.xcconfig"
 #include "Generated.xcconfig"
+CODE_SIGN_STYLE=Manual
+PROVISIONING_PROFILE_SPECIFIER=
+DEVELOPMENT_TEAM=

--- a/ios/Flutter/Profile-prod.xcconfig
+++ b/ios/Flutter/Profile-prod.xcconfig
@@ -1,2 +1,5 @@
 #include? "../Pods/Target Support Files/Pods-Runner/Pods-Runner.profile-prod.xcconfig"
 #include "Generated.xcconfig"
+CODE_SIGN_STYLE=Manual
+PROVISIONING_PROFILE_SPECIFIER=
+DEVELOPMENT_TEAM=

--- a/ios/Flutter/Profile-staging.xcconfig
+++ b/ios/Flutter/Profile-staging.xcconfig
@@ -1,2 +1,5 @@
 #include? "../Pods/Target Support Files/Pods-Runner/Pods-Runner.profile-staging.xcconfig"
 #include "Generated.xcconfig"
+CODE_SIGN_STYLE=Manual
+PROVISIONING_PROFILE_SPECIFIER=
+DEVELOPMENT_TEAM=

--- a/ios/Flutter/Release-dev.xcconfig
+++ b/ios/Flutter/Release-dev.xcconfig
@@ -1,2 +1,5 @@
 #include? "../Pods/Target Support Files/Pods-Runner/Pods-Runner.release-dev.xcconfig"
 #include "Generated.xcconfig"
+CODE_SIGN_STYLE=Manual
+PROVISIONING_PROFILE_SPECIFIER=
+DEVELOPMENT_TEAM=

--- a/ios/Flutter/Release-prod.xcconfig
+++ b/ios/Flutter/Release-prod.xcconfig
@@ -1,2 +1,5 @@
 #include? "../Pods/Target Support Files/Pods-Runner/Pods-Runner.release-prod.xcconfig"
 #include "Generated.xcconfig"
+CODE_SIGN_STYLE=Manual
+PROVISIONING_PROFILE_SPECIFIER=
+DEVELOPMENT_TEAM=

--- a/ios/Flutter/Release-staging.xcconfig
+++ b/ios/Flutter/Release-staging.xcconfig
@@ -1,2 +1,5 @@
 #include? "../Pods/Target Support Files/Pods-Runner/Pods-Runner.release-staging.xcconfig"
 #include "Generated.xcconfig"
+CODE_SIGN_STYLE=Manual
+PROVISIONING_PROFILE_SPECIFIER=
+DEVELOPMENT_TEAM=

--- a/ios/Runner.xcodeproj/project.pbxproj
+++ b/ios/Runner.xcodeproj/project.pbxproj
@@ -463,7 +463,7 @@
 			baseConfigurationReference = 0EC5EAD0424AD61A24F91BA7 /* Pods-RunnerTests.profile-prod.xcconfig */;
 			buildSettings = {
 				BUNDLE_LOADER = "$(TEST_HOST)";
-				CODE_SIGN_STYLE = Automatic;
+				CODE_SIGN_STYLE = Manual;
 				CURRENT_PROJECT_VERSION = 1;
 				GENERATE_INFOPLIST_FILE = YES;
 				MARKETING_VERSION = 1.0;
@@ -479,7 +479,7 @@
 			baseConfigurationReference = 36387229A3C23CE302366E09 /* Pods-RunnerTests.release-staging.xcconfig */;
 			buildSettings = {
 				BUNDLE_LOADER = "$(TEST_HOST)";
-				CODE_SIGN_STYLE = Automatic;
+				CODE_SIGN_STYLE = Manual;
 				CURRENT_PROJECT_VERSION = 1;
 				GENERATE_INFOPLIST_FILE = YES;
 				MARKETING_VERSION = 1.0;
@@ -605,7 +605,7 @@
 			baseConfigurationReference = 78051479F73C9F7F75A66151 /* Pods-RunnerTests.debug-prod.xcconfig */;
 			buildSettings = {
 				BUNDLE_LOADER = "$(TEST_HOST)";
-				CODE_SIGN_STYLE = Automatic;
+				CODE_SIGN_STYLE = Manual;
 				CURRENT_PROJECT_VERSION = 1;
 				GENERATE_INFOPLIST_FILE = YES;
 				MARKETING_VERSION = 1.0;
@@ -789,7 +789,7 @@
 			baseConfigurationReference = 2A0F71A7824324AA2673457D /* Pods-RunnerTests.release-prod.xcconfig */;
 			buildSettings = {
 				BUNDLE_LOADER = "$(TEST_HOST)";
-				CODE_SIGN_STYLE = Automatic;
+				CODE_SIGN_STYLE = Manual;
 				CURRENT_PROJECT_VERSION = 1;
 				GENERATE_INFOPLIST_FILE = YES;
 				MARKETING_VERSION = 1.0;
@@ -926,7 +926,7 @@
 			baseConfigurationReference = 77B707702A0953A01E8525E2 /* Pods-RunnerTests.profile-staging.xcconfig */;
 			buildSettings = {
 				BUNDLE_LOADER = "$(TEST_HOST)";
-				CODE_SIGN_STYLE = Automatic;
+				CODE_SIGN_STYLE = Manual;
 				CURRENT_PROJECT_VERSION = 1;
 				GENERATE_INFOPLIST_FILE = YES;
 				MARKETING_VERSION = 1.0;
@@ -1039,7 +1039,7 @@
 			baseConfigurationReference = C4D5FE8BED71A8362433D84C /* Pods-RunnerTests.release-dev.xcconfig */;
 			buildSettings = {
 				BUNDLE_LOADER = "$(TEST_HOST)";
-				CODE_SIGN_STYLE = Automatic;
+				CODE_SIGN_STYLE = Manual;
 				CURRENT_PROJECT_VERSION = 1;
 				GENERATE_INFOPLIST_FILE = YES;
 				MARKETING_VERSION = 1.0;
@@ -1055,7 +1055,7 @@
 			baseConfigurationReference = 332FAF4210EE7C66DC691686 /* Pods-RunnerTests.profile-dev.xcconfig */;
 			buildSettings = {
 				BUNDLE_LOADER = "$(TEST_HOST)";
-				CODE_SIGN_STYLE = Automatic;
+				CODE_SIGN_STYLE = Manual;
 				CURRENT_PROJECT_VERSION = 1;
 				GENERATE_INFOPLIST_FILE = YES;
 				MARKETING_VERSION = 1.0;
@@ -1195,7 +1195,7 @@
 			baseConfigurationReference = 986EBEBC61280F828AAE08C7 /* Pods-RunnerTests.debug-staging.xcconfig */;
 			buildSettings = {
 				BUNDLE_LOADER = "$(TEST_HOST)";
-				CODE_SIGN_STYLE = Automatic;
+				CODE_SIGN_STYLE = Manual;
 				CURRENT_PROJECT_VERSION = 1;
 				GENERATE_INFOPLIST_FILE = YES;
 				MARKETING_VERSION = 1.0;
@@ -1236,7 +1236,7 @@
 			baseConfigurationReference = 86BC411E3063EC0A86DC656A /* Pods-RunnerTests.debug-dev.xcconfig */;
 			buildSettings = {
 				BUNDLE_LOADER = "$(TEST_HOST)";
-				CODE_SIGN_STYLE = Automatic;
+				CODE_SIGN_STYLE = Manual;
 				CURRENT_PROJECT_VERSION = 1;
 				GENERATE_INFOPLIST_FILE = YES;
 				MARKETING_VERSION = 1.0;

--- a/ui/public_profile/pubspec.yaml
+++ b/ui/public_profile/pubspec.yaml
@@ -18,3 +18,7 @@ dependencies:
     path: ../../features/movies
   movies_ui:
     path: ../movies_ui
+
+dev_dependencies:
+  auto_route_generator: ^10.5.0
+  build_runner: ^2.13.1

--- a/ui/social/pubspec.yaml
+++ b/ui/social/pubspec.yaml
@@ -15,3 +15,7 @@ dependencies:
     path: ../common
   public_profile:
     path: ../public_profile
+
+dev_dependencies:
+  auto_route_generator: ^10.5.0
+  build_runner: ^2.13.1


### PR DESCRIPTION
## Summary
- Set `CODE_SIGN_STYLE` to `Manual` across all xcconfigs and `project.pbxproj`
- Add `simulator` option to `ios build` lane (`bundle exec fastlane ios build simulator:true`)
- Add `codegen` lane to run `build_runner` across all packages (`bundle exec fastlane codegen`)
- Add missing `build_runner` and `auto_route_generator` dev_dependencies to `ui/social` and `ui/public_profile`

## Test plan
- [x] `bundle exec fastlane ios build simulator:true` builds successfully
- [x] `bundle exec fastlane codegen` runs build_runner across all 9 packages