### PR TITLE
fix: remove push trigger from ci workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,19 +1,6 @@
 name: CI - Build and Test
 
 on:
-  push:
-    branches:
-      - dev
-      - main
-    paths:
-      - 'lib/**'
-      - 'ios/**'
-      - 'android/**'
-      - 'test/**'
-      - 'fastlane/**'
-      - '.github/**'
-      - '.actions.yml'
-      - 'pubspec.yaml'
   pull_request:
     branches:
       - dev


### PR DESCRIPTION
Since dev and main branches are protected, all code changes must pass CI checks via PR before merging. Running CI on push to protected branches duplicates work already validated by PR checks.

## Changes
- Remove push trigger from CI workflow
- Keep only pull_request events

This prevents redundant CI runs and saves pipeline resources.