### PR TITLE
fix: remove push trigger from ci workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,19 +1,6 @@
 name: CI - Build and Test
 
 on:
-  push:
-    branches:
-      - dev
-      - main
-    paths:
-      - 'lib/**'
-      - 'ios/**'
-      - 'android/**'
-      - 'test/**'
-      - 'fastlane/**'
-      - '.github/**'
-      - '.actions.yml'
-      - 'pubspec.yaml'
   pull_request:
     branches:
       - dev


### PR DESCRIPTION
Merge dev to main with CI workflow fix.

Removes redundant push trigger from CI workflow since dev and main branches are protected. All code changes must pass CI checks via PR before merging, making push-triggered checks redundant.